### PR TITLE
Enable lambda functions as transformers in use_with.

### DIFF
--- a/ramda/use_with.py
+++ b/ramda/use_with.py
@@ -22,14 +22,16 @@ def use_with(function, transformers):
 
     run = []
     for i, t in enumerate(transformers):
-        F[t.__name__] = t
+
+        transformer_name = f'fn_{i}' if t.__name__ == '<lambda>' else t.__name__
+
+        F[transformer_name] = t
         try:
             args[i]
         except (IndexError, TypeError):
             args.append("argument" + str(i))
 
-        run.append(t.__name__ + "(" + args[i] + ")")
-
+        run.append(transformer_name + "(" + args[i] + ")")
     f = (
         "lambda "
         + ", ".join(args[: len(transformers)])

--- a/ramda/use_with_test.py
+++ b/ramda/use_with_test.py
@@ -7,3 +7,5 @@ def use_with_test():
     assert_equal(use_with(pow, [identity, identity])(3)(4), 81)
     assert_equal(use_with(pow, [dec, inc])(3, 4), 32)
     assert_equal(use_with(pow, [dec, inc])(3)(4), 32)
+
+    assert_equal(use_with(pow, [lambda x: x-1, inc])(3, 4), 32)


### PR DESCRIPTION
Fix #13 by checking for `lambda` in function names.